### PR TITLE
test: log ResourceGroup diff on unexpected updates

### DIFF
--- a/e2e/testcases/resource_group_controller_test.go
+++ b/e2e/testcases/resource_group_controller_test.go
@@ -543,7 +543,9 @@ func TestResourceGroupApplyStatus(t *testing.T) {
 	err := nt.Watcher.WatchObject(kinds.ResourceGroup(), rgNN.Name, rgNN.Namespace,
 		testwatcher.WatchPredicates(
 			testpredicates.ResourceVersionNotEquals(nt.Scheme, resourceVersion),
-		), testwatcher.WatchTimeout(60*time.Second))
+		),
+		testwatcher.WatchTimeout(60*time.Second),
+		testwatcher.AlwaysLogDiff()) // Always log diff since no updates are expected. This helps with debugging.
 	if err == nil {
 		nt.T.Fatal("expected ResourceGroup ResourceVersion to not change")
 	}


### PR DESCRIPTION
This change updates TestResourceGroupApplyStatus to always log the diff when an unexpected ResourceGroup update happens. This test has been somewhat flaky and this additional logging is intended to help understand the root cause of the test flake.