### PR TITLE
test: add remote values file for use by hydration test

### DIFF
--- a/e2e/testdata/hydration/remote-values.yaml
+++ b/e2e/testdata/hydration/remote-values.yaml
@@ -1,0 +1,5 @@
+annotations:
+  foo: remote-baz
+data:
+  image:
+    imagePullPolicy: Always


### PR DESCRIPTION
Adds `remote-values.yaml` which will be referenced here after this PR has merged https://github.com/GoogleContainerTools/config-sync/blob/b1659c74340f8f26a825eea2b14d09afbd8fee87/e2e/testdata/hydration/helm-components-remote-values-kustomization.yaml#L19
This file is used by `TestHydrateHelmComponents`
