### PR TITLE
chore: bump Helm and otelcontribcol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ KUSTOMIZE_STAGING_DIR := $(OUTPUT_DIR)/third_party/kustomize
 
 # To automatically update, run this command:
 # UPDATE_TYPE=<latest-version|latest-build> make update-helm-image
-HELM_VERSION := v3.21.1-gke.7
+HELM_VERSION := v3.21.1-gke.9
 HELM := $(BIN_DIR)/helm
 HELM_STAGING_DIR := $(OUTPUT_DIR)/third_party/helm
 
@@ -100,7 +100,7 @@ GIT_SYNC_IMAGE_NAME := gcr.io/config-management-release/git-sync:$(GIT_SYNC_VERS
 
 # To automatically update, run this command:
 # UPDATE_TYPE=<latest-version|latest-build> make update-otelcontribcol-image
-OTELCONTRIBCOL_VERSION := v0.152.0-gke.16
+OTELCONTRIBCOL_VERSION := v0.152.0-gke.17
 OTELCONTRIBCOL_IMAGE_NAME := gcr.io/config-management-release/otelcontribcol:$(OTELCONTRIBCOL_VERSION)
 
 # Directory used for staging Docker contexts.

--- a/pkg/hydrate/tool_util.go
+++ b/pkg/hydrate/tool_util.go
@@ -45,7 +45,7 @@ import (
 
 const (
 	// HelmVersion is the recommended version of Helm for hydration.
-	HelmVersion = "v3.21.1-gke.7"
+	HelmVersion = "v3.21.1-gke.9"
 	// KustomizeVersion is the recommended version of Kustomize for hydration.
 	KustomizeVersion = "v5.4.2-gke.11"
 	// Helm is the binary name of the installed Helm.


### PR DESCRIPTION
- Bumps Helm to v3.21.1-gke.9
- Bumps otelcontribcol to v0.152.0-gke.17